### PR TITLE
Fix pep8

### DIFF
--- a/tests/test_uritemplate.py
+++ b/tests/test_uritemplate.py
@@ -544,24 +544,24 @@ class TestURIVariable(TestCase):
 
 class TestVariableModule(TestCase):
     def test_is_list_of_tuples(self):
-        l = [(1, 2), (3, 4)]
-        self.assertEqual(variable.is_list_of_tuples(l), (True, l))
+        a_list = [(1, 2), (3, 4)]
+        self.assertEqual(variable.is_list_of_tuples(a_list), (True, a_list))
 
-        l = [1, 2, 3, 4]
-        self.assertEqual(variable.is_list_of_tuples(l), (False, None))
+        a_list = [1, 2, 3, 4]
+        self.assertEqual(variable.is_list_of_tuples(a_list), (False, None))
 
     def test_list_test(self):
-        l = [1, 2, 3, 4]
-        self.assertEqual(variable.list_test(l), True)
+        a_list = [1, 2, 3, 4]
+        self.assertEqual(variable.list_test(a_list), True)
 
-        l = str([1, 2, 3, 4])
-        self.assertEqual(variable.list_test(l), False)
+        a_list = str([1, 2, 3, 4])
+        self.assertEqual(variable.list_test(a_list), False)
 
     def test_list_of_tuples_test(self):
-        l = [(1, 2), (3, 4)]
-        self.assertEqual(variable.dict_test(l), False)
+        a_list = [(1, 2), (3, 4)]
+        self.assertEqual(variable.dict_test(a_list), False)
 
-        d = dict(l)
+        d = dict(a_list)
         self.assertEqual(variable.dict_test(d), True)
 
 


### PR DESCRIPTION
The pep8 CI build is failing due to an update to pycodestyle:

```
pep8 runtests: commands[0] | flake8 uritemplate tests setup.py
tests/test_uritemplate.py:547:9: E741 ambiguous variable name 'l'
tests/test_uritemplate.py:550:9: E741 ambiguous variable name 'l'
tests/test_uritemplate.py:554:9: E741 ambiguous variable name 'l'
tests/test_uritemplate.py:557:9: E741 ambiguous variable name 'l'
tests/test_uritemplate.py:561:9: E741 ambiguous variable name 'l'
```

https://travis-ci.org/hugovk/uritemplate/jobs/425273657