### PR TITLE
Import ABCs from collections.abc if possible

### DIFF
--- a/uritemplate/orderedset.py
+++ b/uritemplate/orderedset.py
@@ -1,14 +1,18 @@
 # From: https://github.com/ActiveState/code/blob/master/recipes/Python/576696_OrderedSet_with_Weakrefs/  # noqa
 
-import collections
 from weakref import proxy
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 
 class Link(object):
     __slots__ = 'prev', 'next', 'key', '__weakref__'
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections_abc.MutableSet):
     'Set the remembers the order elements were added'
     # Big-O running times for all methods are the same as for regular sets.
     # The internal self.__map dictionary maps keys to links in a doubly linked

--- a/uritemplate/variable.py
+++ b/uritemplate/variable.py
@@ -15,8 +15,12 @@ What do you do?
 
 """
 
-import collections
 import sys
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 if sys.version_info.major == 2:
     import urllib
@@ -360,7 +364,7 @@ def list_test(value):
 
 
 def dict_test(value):
-    return isinstance(value, (dict, collections.MutableMapping))
+    return isinstance(value, (dict, collections_abc.MutableMapping))
 
 
 try:


### PR DESCRIPTION
Using `collections.MutableSet` and `collections.MutableMapping` produces a `DeprecationWarning` under Python 3.7 with the message:

> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

This patch eliminates this warning by importing the ABCs from `collections.abc`, falling back to `collections` only if that fails (i.e., if running under Python < 3.3).