### PR TITLE
Correct handling of empty/undef in list values

### DIFF
--- a/tests/test_uritemplate.py
+++ b/tests/test_uritemplate.py
@@ -470,10 +470,22 @@ class TestURITemplate(RFCTemplateExamples('RFCMeta', (TestCase,), {})):
             'foo', [], True, '/'), None
         )
         self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', [None], True, '/'), None
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', [None, None], True, '/'), None
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
             'foo', ['one'], True, '/'), 'one'
         )
         self.assertEqual(t.variables[0]._label_path_expansion(
             'foo', ['one', 'two'], True, '/'), 'one/two'
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', ['one', None, 'two'], True, '/'), 'one/two'
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', [''], True, '/'), ''
         )
         self.assertEqual(t.variables[0]._label_path_expansion(
             'foo', ['', ''], True, '/'), '/'

--- a/tests/test_uritemplate.py
+++ b/tests/test_uritemplate.py
@@ -464,6 +464,40 @@ class TestURITemplate(RFCTemplateExamples('RFCMeta', (TestCase,), {})):
             None
         )
 
+    def test_label_path_expansion_explode_slash(self):
+        t = URITemplate('{/foo*}')
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', [], True, '/'), None
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', ['one'], True, '/'), 'one'
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', ['one', 'two'], True, '/'), 'one/two'
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', ['', ''], True, '/'), '/'
+        )
+
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {}, True, '/'), None
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {'one': ''}, True, '/'), 'one='
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {'one': '', 'two': ''}, True, '/'), 'one=/two='
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {'one': None}, True, '/'), None
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {'one': None, 'two': 'two'}, True, '/'), 'two=two'
+        )
+        self.assertEqual(t.variables[0]._label_path_expansion(
+            'foo', {'one': None, 'two': None}, True, '/'), None
+        )
+
     def test_semi_path_expansion(self):
         t = URITemplate('{foo}')
         v = t.variables[0]

--- a/uritemplate/variable.py
+++ b/uritemplate/variable.py
@@ -200,10 +200,8 @@ class URIVariable(object):
             if not explode:
                 join_str = ','
 
-            expanded = join_str.join(
-                quote(v, safe) for v in value if value is not None
-            )
-            return expanded if expanded else None
+            fragments = [quote(v, safe) for v in value if v is not None]
+            return join_str.join(fragments) if fragments else None
 
         if dict_test(value) or tuples:
             items = items or sorted(value.items())


### PR DESCRIPTION
- Expansion of a list including `None` values, violating 3.2.1 as the
  undefined value is not ignored, e.g.

```pycon 
>>> expand('/test{/x*}', x=['one', None, 'three']) 
'/test/one/None/three'  # violates 3.2.1
``` 

- A list with empty string was ignored, violating 2.3 as this should not
  be tread as undefined, example:

```pycon
>>> expand('/test{/x}', x=[])
'/test'
>>> expand('/test{/x}', x='')
'/test/'
>>> expand('/test{/x}', x=[''])
'/test'  # should be '/test/' like above
>>> expand('/test{/x}', x=['', ''])
'/test/,'
>>> expand('/test{/x*}', x=['', ''])
'/test//'
>>> expand('/test{/x*}', x=[''])
'/test'  # again, should be '/test/'
```
