### PR TITLE
Update support for Python 3.7 & 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - env: TOXENV=pep8
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from io import open
+
 from setuptools import setup
 
 from uritemplate import __version__

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,17 @@ packages = [
     'uritemplate'
 ]
 
+with open("README.rst") as file:
+    readme = file.read()
+
+with open("HISTORY.rst") as file:
+    history = file.read()
+
 setup(
     name="uritemplate",
     version=__version__,
     description='URI templates',
-    long_description="\n\n".join([open("README.rst").read(),
-                                  open("HISTORY.rst").read()]),
+    long_description="\n\n".join([readme, history]),
     license="BSD 3-Clause License or Apache License, Version 2.0",
     author="Ian Stapleton Cordasco",
     author_email="graffatcolmingov@gmail.com",
@@ -34,6 +39,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ packages = [
     'uritemplate'
 ]
 
-with open("README.rst") as file:
+with open("README.rst", encoding="utf-8") as file:
     readme = file.read()
 
-with open("HISTORY.rst") as file:
+with open("HISTORY.rst", encoding="utf-8") as file:
     history = file.read()
 
 setup(

--- a/tests/fixtures/extended-tests.json
+++ b/tests/fixtures/extended-tests.json
@@ -11,7 +11,7 @@
             "lang"         : "en",
             "geocode"      : ["37.76","-122.427"],
             "first_name"   : "John",
-            "last.name"    : "Doe", 
+            "last.name"    : "Doe",
             "Some%20Thing" : "foo",
             "number"       : 6,
             "long"         : 37.76,
@@ -28,7 +28,7 @@
         "testcases":[
 
             [ "{/id*}" , "/person" ],
-            [ "{/id*}{?fields,first_name,last.name,token}" , [ 
+            [ "{/id*}{?fields,first_name,last.name,token}" , [
             	"/person?fields=id,name,picture&first_name=John&last.name=Doe&token=12345",
             	"/person?fields=id,picture,name&first_name=John&last.name=Doe&token=12345",
             	"/person?fields=picture,name,id&first_name=John&last.name=Doe&token=12345",
@@ -46,10 +46,16 @@
             ["/base{/group_id,first_name}/pages{/page,lang}{?format,q}","/base/12345/John/pages/5/en?format=json&q=URI%20Templates"],
             ["/sparql{?query}", "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D"],
             ["/go{?uri}", "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F"],
-            ["/service{?word}", "/service?word=dr%C3%BCcken"],
-            ["/lookup{?Stra%C3%9Fe}", "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg"],
-            ["{random}" , "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"],
-            ["{?assoc_special_chars*}", "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"]
+            ["/service{?word}", [ "/service?word=dr%C3%BCcken", "/service?word=dr%C3%83%C2%BCcken"]],
+            ["/lookup{?Stra%C3%9Fe}", ["/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg", "/lookup?Stra%C3%9Fe=Gr%C3%83%C2%BCner%20Weg"]],
+            ["{random}",
+                [ "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF",
+                  "%C3%85%C2%A1%C3%83%C2%B6%C3%83%C2%A4%C3%85%C2%B8%C3%85%E2%80%9C%C3%83%C2%B1%C3%83%C2%AA%C3%A2%E2%80%9A%C2%AC%C3%82%C2%A3%C3%82%C2%A5%C3%A2%E2%82%AC%C2%A1%C3%83%E2%80%98%C3%83%E2%80%99%C3%83%E2%80%9C%C3%83%E2%80%9D%C3%83%E2%80%A2%C3%83%E2%80%93%C3%83%E2%80%94%C3%83%CB%9C%C3%83%E2%84%A2%C3%83%C5%A1%C3%83%C2%A0%C3%83%C2%A1%C3%83%C2%A2%C3%83%C2%A3%C3%83%C2%A4%C3%83%C2%A5%C3%83%C2%A6%C3%83%C2%A7%C3%83%C2%BF"]
+                ],
+            ["{?assoc_special_chars*}",
+                [ "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF",
+                  "?%C3%85%C2%A1%C3%83%C2%B6%C3%83%C2%A4%C3%85%C2%B8%C3%85%E2%80%9C%C3%83%C2%B1%C3%83%C2%AA%C3%A2%E2%80%9A%C2%AC%C3%82%C2%A3%C3%82%C2%A5%C3%A2%E2%82%AC%C2%A1%C3%83%E2%80%98%C3%83%E2%80%99%C3%83%E2%80%9C%C3%83%E2%80%9D%C3%83%E2%80%A2=%C3%83%E2%80%93%C3%83%E2%80%94%C3%83%CB%9C%C3%83%E2%84%A2%C3%83%C5%A1%C3%83%C2%A0%C3%83%C2%A1%C3%83%C2%A2%C3%83%C2%A3%C3%83%C2%A4%C3%83%C2%A5%C3%83%C2%A6%C3%83%C2%A7%C3%83%C2%BF"]
+                ]
         ]
     },
     "Additional Examples 2":{
@@ -68,7 +74,7 @@
         "testcases":[
 
             [ "{/id*}" , ["/person/albums","/albums/person"] ],
-            [ "{/id*}{?fields,token}" , [ 
+            [ "{/id*}{?fields,token}" , [
             	"/person/albums?fields=id,name,picture&token=12345",
             	"/person/albums?fields=id,picture,name&token=12345",
             	"/person/albums?fields=picture,name,id&token=12345",
@@ -112,7 +118,7 @@
             [ "{?42}", "?42=The%20Answer%20to%20the%20Ultimate%20Question%20of%20Life%2C%20the%20Universe%2C%20and%20Everything"],
             [ "{1337}", "leet,as,it,can,be"],
             [ "{?1337*}", "?1337=leet&1337=as&1337=it&1337=can&1337=be"],
-            [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf"] ]
+            [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf", "?11=elf&12=zw%C3%83%C2%B6lf"] ]
         ]
     }
 }

--- a/tests/fixtures/extended-tests.json
+++ b/tests/fixtures/extended-tests.json
@@ -46,16 +46,10 @@
             ["/base{/group_id,first_name}/pages{/page,lang}{?format,q}","/base/12345/John/pages/5/en?format=json&q=URI%20Templates"],
             ["/sparql{?query}", "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D"],
             ["/go{?uri}", "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F"],
-            ["/service{?word}", [ "/service?word=dr%C3%BCcken", "/service?word=dr%C3%83%C2%BCcken"]],
-            ["/lookup{?Stra%C3%9Fe}", ["/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg", "/lookup?Stra%C3%9Fe=Gr%C3%83%C2%BCner%20Weg"]],
-            ["{random}",
-                [ "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF",
-                  "%C3%85%C2%A1%C3%83%C2%B6%C3%83%C2%A4%C3%85%C2%B8%C3%85%E2%80%9C%C3%83%C2%B1%C3%83%C2%AA%C3%A2%E2%80%9A%C2%AC%C3%82%C2%A3%C3%82%C2%A5%C3%A2%E2%82%AC%C2%A1%C3%83%E2%80%98%C3%83%E2%80%99%C3%83%E2%80%9C%C3%83%E2%80%9D%C3%83%E2%80%A2%C3%83%E2%80%93%C3%83%E2%80%94%C3%83%CB%9C%C3%83%E2%84%A2%C3%83%C5%A1%C3%83%C2%A0%C3%83%C2%A1%C3%83%C2%A2%C3%83%C2%A3%C3%83%C2%A4%C3%83%C2%A5%C3%83%C2%A6%C3%83%C2%A7%C3%83%C2%BF"]
-                ],
-            ["{?assoc_special_chars*}",
-                [ "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF",
-                  "?%C3%85%C2%A1%C3%83%C2%B6%C3%83%C2%A4%C3%85%C2%B8%C3%85%E2%80%9C%C3%83%C2%B1%C3%83%C2%AA%C3%A2%E2%80%9A%C2%AC%C3%82%C2%A3%C3%82%C2%A5%C3%A2%E2%82%AC%C2%A1%C3%83%E2%80%98%C3%83%E2%80%99%C3%83%E2%80%9C%C3%83%E2%80%9D%C3%83%E2%80%A2=%C3%83%E2%80%93%C3%83%E2%80%94%C3%83%CB%9C%C3%83%E2%84%A2%C3%83%C5%A1%C3%83%C2%A0%C3%83%C2%A1%C3%83%C2%A2%C3%83%C2%A3%C3%83%C2%A4%C3%83%C2%A5%C3%83%C2%A6%C3%83%C2%A7%C3%83%C2%BF"]
-                ]
+            ["/service{?word}", "/service?word=dr%C3%BCcken"],
+            ["/lookup{?Stra%C3%9Fe}", "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg"],
+            ["{random}" , "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"],
+            ["{?assoc_special_chars*}", "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"]
         ]
     },
     "Additional Examples 2":{
@@ -118,7 +112,7 @@
             [ "{?42}", "?42=The%20Answer%20to%20the%20Ultimate%20Question%20of%20Life%2C%20the%20Universe%2C%20and%20Everything"],
             [ "{1337}", "leet,as,it,can,be"],
             [ "{?1337*}", "?1337=leet&1337=as&1337=it&1337=can&1337=be"],
-            [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf", "?11=elf&12=zw%C3%83%C2%B6lf"] ]
+            [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf"] ]
         ]
     }
 }

--- a/tests/test_from_fixtures.py
+++ b/tests/test_from_fixtures.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os.path
 
@@ -12,7 +13,7 @@ def fixture_file_path(filename):
 
 def load_examples(filename):
     path = fixture_file_path(filename)
-    with open(path, 'r', encoding="utf-8") as examples_file:
+    with io.open(path, 'r', encoding="utf-8") as examples_file:
         examples = json.load(examples_file)
     return examples
 

--- a/tests/test_from_fixtures.py
+++ b/tests/test_from_fixtures.py
@@ -12,7 +12,7 @@ def fixture_file_path(filename):
 
 def load_examples(filename):
     path = fixture_file_path(filename)
-    with open(path, 'r') as examples_file:
+    with open(path, 'r', encoding="utf-8") as examples_file:
         examples = json.load(examples_file)
     return examples
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,14 @@ envlist =
     py34,
     py35,
     py36,
+    py37,
+    py38,
     pep8,
 
 [testenv]
 deps =
     pytest
-commands = py.test {posargs}
+commands = pytest {posargs}
 
 [testenv:pep8]
 deps =


### PR DESCRIPTION
Starting in Python 3.7 the quoting support [changed from RFC 2396 to RFC 3986](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote).