### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,9 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
+keywords = rfc 6570 uri template
 project_urls =
     Source = https://github.com/python-hyper/uritemplate
-keywords = rfc 6570 uri template
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
+project_urls =
+    Source = https://github.com/python-hyper/uritemplate
 keywords = rfc 6570 uri template
 
 [options]


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.