### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,26 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python:
           - { VERSION: "3.6", TOXENV: "py36", ALLOW_FAILURE: false }
           - { VERSION: "3.7", TOXENV: "py37", ALLOW_FAILURE: false }
           - { VERSION: "3.8", TOXENV: "py38", ALLOW_FAILURE: false }
           - { VERSION: "3.9", TOXENV: "py39",ALLOW_FAILURE: false }
-          - { VERSION: "3.10", TOXENV: "py310,pep8,pre-commit", ALLOW_FAILURE: false }
+          - { VERSION: "3.10", TOXENV: "py310",ALLOW_FAILURE: false }
+          - { VERSION: "3.11", TOXENV: "py311,pep8,pre-commit", ALLOW_FAILURE: false }
+          - { VERSION: "3.12", TOXENV: "py312",ALLOW_FAILURE: false }
           - { VERSION: "pypy3", TOXENV: "pypy", ALLOW_FAILURE: false }
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.0.0
       - name: Setup Python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
+          allow-prereleases: true
       - name: Upgrade pip
         run: |
           pip install -U pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - { VERSION: "3.6", TOXENV: "py36", ALLOW_FAILURE: false }
-          - { VERSION: "3.7", TOXENV: "py37", ALLOW_FAILURE: false }
           - { VERSION: "3.8", TOXENV: "py38", ALLOW_FAILURE: false }
           - { VERSION: "3.9", TOXENV: "py39",ALLOW_FAILURE: false }
           - { VERSION: "3.10", TOXENV: "py310",ALLOW_FAILURE: false }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           - { VERSION: "3.10", TOXENV: "py310",ALLOW_FAILURE: false }
           - { VERSION: "3.11", TOXENV: "py311,pep8,pre-commit", ALLOW_FAILURE: false }
           - { VERSION: "3.12", TOXENV: "py312",ALLOW_FAILURE: false }
-          - { VERSION: "pypy3", TOXENV: "pypy", ALLOW_FAILURE: false }
+          - { VERSION: "pypy3.10", TOXENV: "pypy", ALLOW_FAILURE: false }
 
     steps:
       - name: Check out the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,21 +8,21 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.10.0
+    rev: v3.11.0
     hooks:
     -   id: reorder-python-imports
-        args: [--application-directories, '.:src', --py36-plus]
+        args: [--application-directories, '.:src', --py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.11.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
     -   id: mypy
         exclude: ^(docs/|tests/)
@@ -34,4 +34,4 @@ repos:
     rev: v2.4.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--min-py3-version, '3.6']
+        args: [--min-py3-version, '3.8']

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.6
-      env: TOXENV=py36
-    - python: 3.7
-      env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
     - env: TOXENV=pep8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 78
-target-version = ['py36']
+target-version = ['py38']
 safe = true
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist =
     py38,
     py39,
     py310,
+    py311,
+    py312,
     pep8,
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    py36,
-    py37,
     py38,
     py39,
     py310,


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

Also fix the PyPy build: we can no longer say `pypy3` but need a full `pypy3.x` version.