### PR TITLE
Fix mypy type errors by using Mapping instead of Dict

### DIFF
--- a/tests/test_from_fixtures.py
+++ b/tests/test_from_fixtures.py
@@ -11,7 +11,7 @@ def fixture_file_path(filename: str) -> str:
     return os.path.join(absolute_dir, "fixtures", filename)
 
 
-ExampleVariables = uritemplate.variable.VariableValueDict
+ExampleVariables = uritemplate.variable.VariableValueMapping
 ExampleTemplatesAndResults = t.List[t.Tuple[str, t.Union[str, t.List[str]]]]
 
 

--- a/tests/test_uritemplate.py
+++ b/tests/test_uritemplate.py
@@ -11,16 +11,18 @@ from uritemplate import variables
 
 def merge_dicts(
     *args: t.Union[
-        variable.VariableValueDict, t.Dict[str, str], t.Dict[str, t.List[str]]
+        variable.VariableValueMapping,
+        t.Dict[str, str],
+        t.Dict[str, t.List[str]],
     ]
-) -> variable.VariableValueDict:
+) -> variable.VariableValueMapping:
     d: t.Dict[str, variable.VariableValue] = {}
     for arg in args:
         d.update(arg)
     return d
 
 
-ExampleVariables = variable.VariableValueDict
+ExampleVariables = variable.VariableValueMapping
 ExampleTemplatesAndResults = t.List[t.Tuple[str, t.Union[str, t.List[str]]]]
 
 
@@ -582,7 +584,7 @@ class TestURITemplate(unittest.TestCase, metaclass=RFCTemplateExamples):
         self.assertEqual(d, {t: 2})
 
     def test_no_mutate(self) -> None:
-        args: variable.VariableValueDict = {}
+        args: variable.VariableValueMapping = {}
         t = URITemplate("")
         t.expand(args, key=1)
         self.assertEqual(args, {})
@@ -635,7 +637,7 @@ class TestAPI(unittest.TestCase):
 
 
 class TestNativeTypeSupport(unittest.TestCase):
-    context: variable.VariableValueDict = {
+    context: variable.VariableValueMapping = {
         "zero": 0,
         "one": 1,
         "digits": list(range(10)),

--- a/uritemplate/api.py
+++ b/uritemplate/api.py
@@ -18,7 +18,7 @@ __all__ = ("OrderedSet", "URITemplate", "expand", "partial", "variables")
 
 def expand(
     uri: str,
-    var_dict: t.Optional[variable.VariableValueDict] = None,
+    var_dict: t.Optional[variable.VariableValueMapping] = None,
     **kwargs: variable.VariableValue,
 ) -> str:
     """Expand the template with the given parameters.
@@ -46,7 +46,7 @@ def expand(
 
 def partial(
     uri: str,
-    var_dict: t.Optional[variable.VariableValueDict] = None,
+    var_dict: t.Optional[variable.VariableValueMapping] = None,
     **kwargs: variable.VariableValue,
 ) -> URITemplate:
     """Partially expand the template with the given parameters.

--- a/uritemplate/template.py
+++ b/uritemplate/template.py
@@ -25,11 +25,11 @@ template_re = re.compile("{([^}]+)}")
 
 
 def _merge(
-    var_dict: t.Optional[variable.VariableValueDict],
-    overrides: variable.VariableValueDict,
-) -> variable.VariableValueDict:
+    var_dict: t.Optional[variable.VariableValueMapping],
+    overrides: variable.VariableValueMapping,
+) -> variable.VariableValueMapping:
     if var_dict:
-        opts = var_dict.copy()
+        opts = dict(var_dict)
         opts.update(overrides)
         return opts
     return overrides
@@ -97,7 +97,7 @@ class URITemplate:
         return hash(self.uri)
 
     def _expand(
-        self, var_dict: variable.VariableValueDict, replace: bool
+        self, var_dict: variable.VariableValueMapping, replace: bool
     ) -> str:
         if not self.variables:
             return self.uri
@@ -121,7 +121,7 @@ class URITemplate:
 
     def expand(
         self,
-        var_dict: t.Optional[variable.VariableValueDict] = None,
+        var_dict: t.Optional[variable.VariableValueMapping] = None,
         **kwargs: variable.VariableValue,
     ) -> str:
         """Expand the template with the given parameters.
@@ -148,7 +148,7 @@ class URITemplate:
 
     def partial(
         self,
-        var_dict: t.Optional[variable.VariableValueDict] = None,
+        var_dict: t.Optional[variable.VariableValueMapping] = None,
         **kwargs: variable.VariableValue,
     ) -> "URITemplate":
         """Partially expand the template with the given parameters.

--- a/uritemplate/variable.py
+++ b/uritemplate/variable.py
@@ -29,7 +29,7 @@ VariableValue = t.Union[
     t.Tuple[str, ScalarVariableValue],
     ScalarVariableValue,
 ]
-VariableValueDict = t.Dict[str, VariableValue]
+VariableValueMapping = t.Mapping[str, VariableValue]
 
 
 _UNRESERVED_CHARACTERS: t.Final[str] = (
@@ -451,7 +451,7 @@ class URIVariable:
         return self.operator.quote(value)
 
     def expand(
-        self, var_dict: t.Optional[VariableValueDict] = None
+        self, var_dict: t.Optional[VariableValueMapping] = None
     ) -> t.Mapping[str, str]:
         """Expand the variable in question.
 


### PR DESCRIPTION
## Summary

This PR fixes mypy type errors that occur when passing simple dictionaries to URI template expansion methods. The core issue is that `Dict` is **invariant** in its value type, while `Mapping` is **covariant**, allowing for more flexible type checking.

## Problem

When users try to expand templates with a simple dictionary, mypy raises type errors:

```python
params: dict[str, str] = {'param1': 'abc', 'param2': 'xyz'}
template.expand(params)
```

**Mypy error:**
```
error: Argument 1 to "expand" of "URITemplate" has incompatible type "dict[str, str]"; 
       expected "dict[str, Sequence[int | float | complex | str | None] | list[int | float | complex | str | None] | 
       Mapping[str, int | float | complex | str | None] | tuple[str, int | float | complex | str | None] | 
       int | float | complex | str | None] | None"  [arg-type]
note: "dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
note: Consider using "Mapping" instead, which is covariant in the value type
```

### Why does this happen?

The issue stems from **type variance**:

- **`Dict[str, VariableValue]` is invariant**: A `dict[str, str]` is NOT compatible with `Dict[str, VariableValue]`, even though `str` is part of the `VariableValue` union
- **`Mapping[str, VariableValue]` is covariant**: A `Mapping[str, str]` IS compatible with `Mapping[str, VariableValue]` because mappings are read-only

Since the expansion functions only **read** from the dictionary (they don't mutate it), `Mapping` is the correct type annotation.

## Changes Made

### 1. Renamed type alias to better reflect immutability
```python
# Before
VariableValueDict = t.Dict[str, VariableValue]

# After  
VariableValueMapping = t.Mapping[str, VariableValue]
```

### 2. Fixed the `_merge()` function
The `Mapping` type doesn't have a `.copy()` method, so we use the `dict()` constructor instead:

```python
# Before
def _merge(...) -> VariableValueDict:
    if var_dict:
        opts = var_dict.copy()  # Error: Mapping has no attribute 'copy'
        
# After
def _merge(...) -> VariableValueMapping:
    if var_dict:
        opts = dict(var_dict)  # Works with any Mapping
```

### 3. Updated all type annotations
- `uritemplate/variable.py`: Updated type alias definition
- `uritemplate/template.py`: Updated `_merge()`, `_expand()`, `expand()`, `partial()` 
- `uritemplate/api.py`: Updated `expand()` and `partial()` functions
- `tests/`: Updated all test type annotations for consistency

## Benefits

1. **Fixes user-facing mypy errors**: Users can now pass `dict[str, str]` without type errors
2. **Better type semantics**: `Mapping` better expresses that the functions don't mutate inputs
3. **More flexible**: Accepts any mapping-like object (dict, OrderedDict, ChainMap, etc.)
4. **Backwards compatible**: `dict` is a subtype of `Mapping`, so all existing code works

## Testing

- [x] All pre-commit hooks pass (including mypy)
- [x] All existing tests pass
- [x] No behavioral changes - only type annotations
- [x] Verified that `dict[str, str]` can now be passed to `expand()` without mypy errors

## References

- [Mypy documentation on variance](https://mypy.readthedocs.io/en/stable/common_issues.html#variance)
- [PEP 483 - The Theory of Type Hints](https://www.python.org/dev/peps/pep-0483/#covariance-and-contravariance)