### PR TITLE
Encode disallowed characters around already percent-encoded triples

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 Changelog - uritemplate
 =======================
 
+Unreleased
+----------
+
+- Fix bug where reserved (``+``) and fragment (``#``) expansion left
+  disallowed characters (such as spaces) unencoded whenever the value also
+  contained an already percent-encoded triple. This was a regression from the
+  fix for
+  `issue #99 <https://github.com/python-hyper/uritemplate/issues/99>`_.
+
 4.2.0 - 2025-06-01
 ------------------
 

--- a/tests/test_uritemplate.py
+++ b/tests/test_uritemplate.py
@@ -589,6 +589,20 @@ class TestURITemplate(unittest.TestCase, metaclass=RFCTemplateExamples):
         t.expand(args, key=1)
         self.assertEqual(args, {})
 
+    def test_reserved_expansion_encodes_around_pct_triples(self) -> None:
+        # A value mixing disallowed characters with an already valid
+        # percent-encoded triple must still encode the disallowed characters
+        # (the triple is preserved, the rest is quoted) -- RFC 6570 3.2.3.
+        self.assertEqual(URITemplate("{+v}").expand(v="a b%20c"), "a%20b%20c")
+        self.assertEqual(
+            URITemplate("{#v}").expand(v="x y%20z"), "#x%20y%20z"
+        )
+        # Uppercase triple preserved; reserved characters left untouched.
+        self.assertEqual(URITemplate("{+v}").expand(v="a%2Fb c"), "a%2Fb%20c")
+        # No triple present -> ordinary quoting; all triples -> left as-is.
+        self.assertEqual(URITemplate("{+v}").expand(v="a b c"), "a%20b%20c")
+        self.assertEqual(URITemplate("{+v}").expand(v="%20"), "%20")
+
 
 class TestVariableModule(unittest.TestCase):
     def test_is_list_of_tuples(self) -> None:

--- a/uritemplate/variable.py
+++ b/uritemplate/variable.py
@@ -17,6 +17,7 @@ What do you do?
 
 import collections.abc
 import enum
+import re
 import string
 import typing as t
 import urllib.parse
@@ -38,6 +39,7 @@ _UNRESERVED_CHARACTERS: t.Final[str] = (
 _GEN_DELIMS: t.Final[str] = ":/?#[]@"
 _SUB_DELIMS: t.Final[str] = "!$&'()*+,;="
 _RESERVED_CHARACTERS: t.Final[str] = f"{_GEN_DELIMS}{_SUB_DELIMS}"
+_PERCENT_ENCODED: t.Final[re.Pattern[str]] = re.compile("%[0-9A-Fa-f]{2}")
 
 
 class Operator(enum.Enum):
@@ -150,9 +152,20 @@ class Operator(enum.Enum):
         return quote(value, "")
 
     def _only_quote_unquoted_characters(self, value: str) -> str:
-        if urllib.parse.unquote(value) == value:
-            return quote(value, _RESERVED_CHARACTERS)
-        return value
+        # For reserved ("+") and fragment ("#") expansion, already
+        # percent-encoded triples must be preserved (RFC 6570 Section 3.2.3).
+        # Quote every other disallowed character while leaving valid triples
+        # untouched, rather than passing the whole value through unquoted as
+        # soon as a single triple is present.
+        result = []
+        last = 0
+        for match in _PERCENT_ENCODED.finditer(value):
+            start, end = match.start(), match.end()
+            result.append(quote(value[last:start], _RESERVED_CHARACTERS))
+            result.append(match.group())
+            last = end
+        result.append(quote(value[last:], _RESERVED_CHARACTERS))
+        return "".join(result)
 
     def quote(self, value: t.Any) -> str:
         if not isinstance(value, (str, bytes)):


### PR DESCRIPTION
### Problem

Reserved (`{+var}`) and fragment (`{#var}`) expansion is supposed to preserve already valid percent-encoded triples while still percent-encoding any other disallowed characters (RFC 6570 [Section 3.2.3](https://www.rfc-editor.org/rfc/rfc6570#section-3.2.3)).

`Operator._only_quote_unquoted_characters` does this with an all-or-nothing check: if `urllib.parse.unquote(value) != value` (i.e. *any* triple is present) it returns the value untouched, which also skips encoding every other disallowed character.

```python
>>> from uritemplate import URITemplate
>>> URITemplate("{+v}").expand(v="a b%20c")
'a b%20c'        # space left raw; expected 'a%20b%20c'
>>> URITemplate("{#v}").expand(v="x y%20z")
'#x y%20z'       # expected '#x%20y%20z'
```

This is a regression introduced by the fix for #99, which addressed the opposite problem (valid triples being double-encoded).

### Fix

Quote the value segment by segment: pass valid percent-encoded triples through verbatim and percent-encode the text between them. Output is identical for values with **no** triples or with **only** triples, so existing behavior is preserved — all current tests still pass, and the new case is now correct:

```python
>>> URITemplate("{+v}").expand(v="a b%20c")
'a%20b%20c'
>>> URITemplate("{+v}").expand(v="a%2Fb c")   # uppercase triple kept, space encoded
'a%2Fb%20c'
```

### Tests

Added `test_reserved_expansion_encodes_around_pct_triples`. It fails on the current code (`a b%20c` → `a%20b%20c`) and passes with the fix; the full suite (59 tests) is green. `black`, `isort`, and `mypy` are clean.
